### PR TITLE
ci: don't build musllinux wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_BUILD: "cp3?-* cp31?-*"
-          CIBW_SKIP: "*-manylinux_i686 *-win32"
+          CIBW_SKIP: "*-manylinux_i686 *-win32 *-musllinux_*"
           CIBW_BUILD_VERBOSITY: "1"
           CIBW_ENVIRONMENT_LINUX: "CFLAGS=-g0 LDFLAGS=-Wl,-strip-debug"
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"


### PR DESCRIPTION
Don't try to build [`muslinux` wheels](https://www.python.org/dev/peps/pep-0656/) for now.