### PR TITLE
Update libusb

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ if sys.platform.startswith('darwin'):
     libusb_ldflags.extend('''
                           -Wl,-framework,IOKit
                           -Wl,-framework,CoreFoundation
+                          -Wl,-framework,Security
                           '''.split())
 # Linux
 elif sys.platform.startswith('linux'):


### PR DESCRIPTION
Summary of the libusb changes:
- darwin: add timeout for reset reenumerate                                       
- darwin: rename darwin_reset_device                                              
- darwin: use detach kernel APIs for capture                                      
- darwin: add authorization for device capture                                    
- darwin: remove redundant macOS version checks                                   
- Update ChangeLog in preparation for 1.0.25                                      
- make libusb.h usable with Watcom                                                
- core: Refactor initialization and how the default context is handled            
- darwin: do not reset darwin_cached_devices on last call to libusb_exit          
- doc: correction of LIBUSB_OPTION_WEAK_AUTHORITY availability                    
- doc: Add since version tag to libusb_wrap_sys_device()                          
- Windows: Support LIBUSB_TRANSFER_ADD_ZERO_PACKET on winusb                      
- Windows: Try alternative methods to query port number                           
- core: allow libusb_set_option on the default context before libusb_init         
- core: ensure that all devices are properly cleaned up on libusb_exit            
- core: only increment devices_released when a device is destroyed                
- winusb: Check for ClassGuid changes on re-enumeration                           
- darwin_set_interface_altsetting: Avoid device reset on pipe error               
- core: really fix dangling devices                                               
- Do not restrict "weak authority" option to Android                              
- darwin: release device parent reference when re-enumerating device              
- Fix build failure on Mac OS X 10.7                                              
- windows: Allow GUID with and without trailing zeroes                            
- New NO_DEVICE_DISCOVERY option to replace WEAK_AUTHORITY option                 
- [Issue-912] Lock open_devs_lock in context to avoid access violation            
- darwin: fix SEGV on libusb_close after failed re-enumeration                    
- darwin: improve support for auto-detaching a kernel driver                      
- winusb: Ignore missing DeviceInterfaceGUID                                      
- darwin: update the list of endpoints after successfull SetAlternateInterface()  
- darwin: add a comment on how the bus number is calculated                       
- darwin: downgrade error message on failure to open interface to info            
- core: update usbi_dbg to take the context as an argument                        
- xusb: add check for interface kernel driver                                     
- darwin: use the IO registry to detect if a kernel driver is attached to an int..
- darwin: only attempt to auto-detach driver is one is active                     
- Update libusb-1.0.def                                                           
- core: set default backend options before calling backend init                   
- configure: remove usage of deprecated AC_HELP_STRING                            
- darwin: fix USB capture for root                                                
- darwin: improve the error message on kernel driver detach failure               
- darwin: fix typo                                                                
- Fix Windows HID backend missing byte                                            
- Android build name correction                                                   
- Fix comment typos                                                               
- Fix segmentation fault in libusb_init() if usbi_backend.init() fails            
- Update Android Readme                                                           
- git hooks: Remove "source" bashism                                              
